### PR TITLE
modify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV WORK_DIR /usr/local/work
 ENV BUILD_DIR $WORK_DIR/build
 ENV TARGET_DIR /opt
 
+
 RUN mkdir -p $WORK_DIR
 
 WORKDIR $WORK_DIR
@@ -12,6 +13,8 @@ WORKDIR $WORK_DIR
 ENV LCMS2_VERSION 2.12
 ENV LCMS2_SOURCE lcms2-${LCMS2_VERSION}.tar.gz
 ENV LCMS2_MD5 8cb583c8447461896320b43ea9a688e0
+
+RUN yum -y install ca-certificates
 
 RUN curl -LO https://downloads.sourceforge.net/lcms/${LCMS2_SOURCE} && \
   (test "$(md5sum ${LCMS2_SOURCE})" = "${LCMS2_MD5}  ${LCMS2_SOURCE}" || { echo 'Checksum Failed'; exit 1; }) && \
@@ -187,8 +190,8 @@ RUN curl -L http://xmlsoft.org/sources/libxml2-${LIBXML2_VERSION}.tar.gz -o ${LI
 
 # ImageMagick
 ENV IMAGEMAGICK_VERSION 7.1.0-2
-ENV IMAGEMAGICK_SOURCE ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz
-ENV IMAGEMAGICK_SHA256 fe8e0781284b99c9ae817c385541db6610c47a5c534e0fd35958d630f194571d
+ENV IMAGEMAGICK_SOURCE ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
+ENV IMAGEMAGICK_SHA256 039006f616bb326598e7b910932694e2a3ca925586560e1b8d153a7048f52980
 
 RUN curl -LO https://download.imagemagick.org/ImageMagick/download/releases/${IMAGEMAGICK_SOURCE} && \
   sha256sum ${IMAGEMAGICK_SOURCE} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ENV WORK_DIR /usr/local/work
 ENV BUILD_DIR $WORK_DIR/build
 ENV TARGET_DIR /opt
 
-
 RUN mkdir -p $WORK_DIR
 
 WORKDIR $WORK_DIR


### PR DESCRIPTION
Dockerfileを修正。
変更点は以下2点。

## ①SSL証明書の有効期限が切れている？ため、curlが通らない
### エラー文（curl: (60) SSL certificate problem: certificate has expired）
>  [ 4/13] RUN curl -LO https://downloads.sourceforge.net/lcms/lcms2-2.12.tar.gz &&   (test "$(md5sum lcms2-2.12.tar.gz)" = "8cb583c8447461896320b43ea9a688e0  lcms2-2.12.tar.gz" || { echo 'Checksum Failed'; exit 1; }) &&   tar xf lcms2-2.12.tar.gz &&   cd lcms2* &&   ./configure     --prefix=/usr/local/work/build     --disable-shared     --enable-static &&   make &&   make install &&   cd .. &&   rm -rf lcms2*:
> #7 0.372   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
> #7 0.373                                  Dload  Upload   Total   Spent    Left  Speed
>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
> #7 0.868 curl: (60) SSL certificate problem: certificate has expired
> #7 0.868 More details here: https://curl.haxx.se/docs/sslcerts.html
> #7 0.868
> #7 0.868 curl failed to verify the legitimacy of the server and therefore could not
> #7 0.868 establish a secure connection to it. To learn more about this situation and
> #7 0.868 how to fix it, please visit the web page mentioned above.

### 対処
⇨curl実行前にca-certificatesをインストールする
> RUN yum -y install ca-certificates


## ②"ImageMagick-7.1.0-2.tar.gz"がリポジトリ上から消失しているため、checksumが失敗に終わる
### エラー文（Checksum Failed）
>  [14/14] RUN curl -LO https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-7.1.0-2.tar.gz &&   sha256sum ImageMagick-7.1.0-2.tar.gz &&   (test "$(sha256sum ImageMagick-7.1.0-2.tar.gz)" = "fe8e0781284b99c9ae817c385541db6610c47a5c534e0fd35958d630f194571d  ImageMagick-7.1.0-2.tar.gz" || { echo 'Checksum Failed'; exit 1; }) &&   tar xf ImageMagick-7.1.0-2.tar.gz &&   cd ImageMagick* &&   PKG_CONFIG_PATH=/usr/local/work/build/lib/pkgconfig ./configure     CPPFLAGS=-I/usr/local/work/build/include     LDFLAGS=-L/usr/local/work/build/lib     --disable-dependency-tracking     --disable-shared     --enable-static     --prefix=/opt     --enable-delegate-build     --without-modules     --disable-docs     --without-magick-plus-plus     --without-perl     --without-x     --disable-openmp &&   make clean &&   make all &&   make install &&   cd .. &&   rm -rf ImageMagick*:
> #17 0.190   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
> #17 0.191                                  Dload  Upload   Total   Spent    Left  Speed
> 100   260  100   260    0     0    269      0 --:--:-- --:--:-- --:--:--   270
> 100   196  100   196    0     0    162      0  0:00:01  0:00:01 --:--:--   162
> #17 1.418 80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880  ImageMagick-7.1.0-2.tar.gz
> #17 1.446 Checksum Failed

### ○対処
⇨"ImageMagick-7.1.0-2.tar.xz"は現存するので、そちらに変更。（合わせてchecksumの値も変更）
>  ENV IMAGEMAGICK_SOURCE ImageMagick-${IMAGEMAGICK_VERSION}.tar.xz
>  ENV IMAGEMAGICK_SHA256 039006f616bb326598e7b910932694e2a3ca925586560e1b8d153a7048f52980